### PR TITLE
fix: Default value generation for lists

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -3,13 +3,16 @@ import { GraphQLSchema } from 'graphql';
 import NodeCustomizer from './NodeCustomizer';
 import React from 'react';
 
-const DefaultValueCustomizerContext = React.createContext<DefaultValueCustomizer>(() => undefined);
+export const DefaultValueCustomizerContext = React.createContext<DefaultValueCustomizer>(
+  () => undefined,
+);
 DefaultValueCustomizerContext.displayName = 'DefaultValueCustomizerContext';
 
-const NodeCustomizerContext = React.createContext<NodeCustomizer>(() => undefined);
+export const DescriptionContext = React.createContext<boolean>(true);
+DescriptionContext.displayName = 'DescriptionContext';
+
+export const NodeCustomizerContext = React.createContext<NodeCustomizer>(() => undefined);
 NodeCustomizerContext.displayName = 'NodeCustomizerContext';
 
-const SchemaContext = React.createContext<GraphQLSchema | undefined>(undefined);
+export const SchemaContext = React.createContext<GraphQLSchema | undefined>(undefined);
 SchemaContext.displayName = 'SchemaContext';
-
-export { DefaultValueCustomizerContext, NodeCustomizerContext, SchemaContext };

--- a/src/GraphiQLTree.module.scss
+++ b/src/GraphiQLTree.module.scss
@@ -8,7 +8,7 @@
     --heading-color: #212833;
     --text-color: #425166;
     --gray100: #eaeaea;
-    --productfy-blue: #1C6EDC;
+    --productfy-blue: #1c6edc;
 
     padding: 2.5vw 5%;
     font-family: var(--body-font);
@@ -24,11 +24,6 @@
       cursor: pointer;
       margin: 0;
       vertical-align: -2px;
-    }
-
-    .arg-name + :local(.typeName),
-    .field-name + :local(.typeName) {
-      margin-left: 8px;
     }
 
     :local(.addRow) {
@@ -54,11 +49,16 @@
         font-size: 13px;
         font-weight: 600;
       }
+
+      > label {
+        padding-left: 22px;
+        display: inline-block;
+      }
     }
 
     :local(.argumentFields) {
       border: 1px solid var(--gray100);
-      margin: 8px 0 8px 1.6em;
+      margin: 8px 0 8px 21px;
 
       &:local(.listable) {
         margin-top: 24px;
@@ -109,8 +109,15 @@
 
     :local(.checkbox) {
       display: inline-block;
-      width: 1em;
-      margin-right: 0.5em;
+      width: 14px;
+      margin-right: 7px;
+    }
+
+    :local(.checkboxGroup) {
+      display: inline-block;
+      white-space: nowrap;
+      margin-left: -22px;
+      margin-right: 7px;
     }
 
     .depth-4 {
@@ -162,6 +169,10 @@
       }
     }
 
+    :local(.hidden) {
+      display: none;
+    }
+
     :local(.implementationType) {
       padding: 12px 0 12px 24px;
       border-bottom: 1px solid #e3e8ee;
@@ -176,7 +187,7 @@
     }
 
     :local(.indented) {
-      padding-left: 1.6em;
+      padding-left: 21px;
     }
 
     :local(.inputField) {
@@ -187,8 +198,9 @@
         border-bottom: none;
       }
 
-      label {
-        white-space: nowrap;
+      > label {
+        padding-left: 22px;
+        display: inline-block;
       }
     }
 
@@ -274,7 +286,7 @@
 
     :local(.nameLine) {
       display: inline-block;
-      white-space: nowrap;
+      padding-left: 22px;
     }
 
     :local(.node) {
@@ -355,7 +367,7 @@
       padding-top: 12px;
 
       > span + :local(.typeName) {
-        margin-left: 8px;
+        margin-left: 7px;
       }
     }
 
@@ -434,9 +446,21 @@
       }
     }
 
+    :local(.toolbar) {
+      margin-top: 6px;
+      margin-bottom: 6px;
+      text-align: right;
+
+      :local(.showDescription) {
+        input[type='checkbox'] {
+          margin-right: 7px;
+        }
+      }
+    }
+
     :local(.typeFields) {
       border: 1px solid var(--gray100);
-      margin: 8px 8px 8px 1.6em;
+      margin: 8px 8px 8px 21px;
     }
 
     :local(.typeName) {

--- a/src/GraphiQLTree.tsx
+++ b/src/GraphiQLTree.tsx
@@ -1,4 +1,9 @@
-import { DefaultValueCustomizerContext, NodeCustomizerContext, SchemaContext } from './Context';
+import {
+  DefaultValueCustomizerContext,
+  DescriptionContext,
+  NodeCustomizerContext,
+  SchemaContext,
+} from './Context';
 import { DocumentNode, GraphQLSchema, parse } from 'graphql';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -37,8 +42,7 @@ export default React.memo(function GraphiQLTree({
   query,
   schema,
 }: GraphiQLTreeProps) {
-  // const [open, setOpen] = useState<boolean>(true);
-  const open = true;
+  const [showDescription, setShowDescription] = useState<boolean>(true);
   const [documentNode, setDocumentNode] = useState<DocumentNode>(
     parseQuery(query) || DEFAULT_DOCUMENT,
   );
@@ -67,22 +71,26 @@ export default React.memo(function GraphiQLTree({
   }, [query]);
 
   return (
-    <div
-      className={classnames('apiDefinition', styles.graphiqlTree)}
-      style={{ ...(!open ? { display: 'none' } : {}) }}
-    >
-      {!schema && (
-        <div className="spinner-container">
-          <div className="spinner" />
-        </div>
-      )}
+    <div className={classnames('apiDefinition', styles.graphiqlTree)}>
+      <div className={classnames('toolbar', styles.toolbar)}>
+        <label className={styles.showDescription}>
+          <input
+            type="checkbox"
+            checked={showDescription}
+            onChange={() => setShowDescription(!showDescription)}
+          />
+          Description
+        </label>
+      </div>
       {schema && (
         <SchemaContext.Provider value={schema}>
-          <NodeCustomizerContext.Provider value={customizeNode}>
-            <DefaultValueCustomizerContext.Provider value={customizeDefaultValue}>
-              <Document documentNode={documentNode} onEdit={onEditDocument} />
-            </DefaultValueCustomizerContext.Provider>
-          </NodeCustomizerContext.Provider>
+          <DescriptionContext.Provider value={showDescription}>
+            <NodeCustomizerContext.Provider value={customizeNode}>
+              <DefaultValueCustomizerContext.Provider value={customizeDefaultValue}>
+                <Document documentNode={documentNode} onEdit={onEditDocument} />
+              </DefaultValueCustomizerContext.Provider>
+            </NodeCustomizerContext.Provider>
+          </DescriptionContext.Provider>
         </SchemaContext.Provider>
       )}
     </div>

--- a/src/GraphiQLWithTree.tsx
+++ b/src/GraphiQLWithTree.tsx
@@ -89,13 +89,13 @@ const GraphiQLWithTree: React.FC<GraphiQLWithTreeProps> = ({
         }),
       );
     }
-  }, [codeMode, parsedQuery, serverUrl, snippets]);
+  }, [codeMode, context, parsedQuery, serverUrl, snippets]);
 
   useEffect(() => {
     if ((graphiqlRef.current as any)?.getQueryEditor()?.options?.readOnly === false) {
       (graphiqlRef.current as any).getQueryEditor().options.readOnly = true;
     }
-  }, [graphiqlRef.current]);
+  });
 
   const copyByCodeMode = () => {
     copy(exportCode);

--- a/src/InputType.tsx
+++ b/src/InputType.tsx
@@ -14,6 +14,7 @@ import {
   isRequiredInputField,
   isScalarType,
 } from 'graphql';
+import { DefaultValueCustomizerContext, DescriptionContext } from './Context';
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import {
   generateArgumentSelectionFromType,
@@ -26,7 +27,6 @@ import {
   unwrapType,
 } from './graphqlHelper';
 
-import { DefaultValueCustomizerContext } from './Context';
 import InputElement from './InputElement';
 import ParentDefinition from './ParentDefinition';
 import TrashIcon from './icons/Trash';
@@ -50,6 +50,7 @@ const InputField = React.memo(function InputField({
   parentDefinition,
 }: InputFieldProps) {
   const customizeDefaultValue = useContext(DefaultValueCustomizerContext);
+  const showDescription = useContext(DescriptionContext);
   const objectFieldNodeRef = useRef(objectFieldNode);
   const parentDefinitionRef = useRef({ definition: inputField, parentDefinition });
   const { name, type } = inputField;
@@ -68,7 +69,11 @@ const InputField = React.memo(function InputField({
         ...objectFieldNodeRef.current!.value,
         values: [
           ...((objectFieldNodeRef.current!.value as ListValueNode).values || []),
-          getDefaultValueByType(unwrappedType, parentDefinitionRef.current, customizeDefaultValue),
+          ...(getDefaultValueByType(
+            type,
+            parentDefinitionRef.current,
+            customizeDefaultValue,
+          ) as ListValueNode).values,
         ],
       } as ListValueNode,
     };
@@ -149,22 +154,23 @@ const InputField = React.memo(function InputField({
   return (
     <div className={classnames(styles.inputField, `depth-${depth}`)}>
       <label>
-        {hasFields && (
-          <span className={`CodeMirror-foldgutter-${isSelected ? 'open' : 'folded'}`} />
-        )}
+        <span className={styles.checkboxGroup}>
+          {hasFields && (
+            <span className={`CodeMirror-foldgutter-${isSelected ? 'open' : 'folded'}`} />
+          )}
 
-        <span className={styles.checkbox}>
-          <input
-            checked={isSelected}
-            disabled={isRequired}
-            onChange={onToggleInputField}
-            type="checkbox"
-            value={isSelected.toString()}
-          />
+          <span className={styles.checkbox}>
+            <input
+              checked={isSelected}
+              disabled={isRequired}
+              onChange={onToggleInputField}
+              type="checkbox"
+              value={isSelected.toString()}
+            />
+          </span>
+
+          <span className={classnames('arg-name', 'cm-attribute', styles.selectable)}>{name}</span>
         </span>
-
-        <span className={classnames('arg-name', 'cm-attribute', styles.selectable)}>{name}</span>
-
         <TypeName className={styles.selectable} isInputType type={type} />
       </label>
 
@@ -211,7 +217,7 @@ const InputField = React.memo(function InputField({
           />
         ))}
 
-      {description && (
+      {showDescription && description && (
         <div className={classnames(styles.description, styles.indented)}>{description}</div>
       )}
 
@@ -296,6 +302,7 @@ const Argument = React.memo(function Argument({
   const argumentNodeRef = useRef(argumentNode);
   const parentDefinitionRef = useRef({ definition: argument, parentDefinition });
   const customizeDefaultValue = useContext(DefaultValueCustomizerContext);
+  const showDescription = useContext(DescriptionContext);
 
   useEffect(() => {
     argumentNodeRef.current = argumentNode;
@@ -308,7 +315,11 @@ const Argument = React.memo(function Argument({
         ...argumentNodeRef.current!.value,
         values: [
           ...((argumentNodeRef.current!.value as ListValueNode).values || []),
-          getDefaultValueByType(unwrappedType, parentDefinitionRef.current, customizeDefaultValue),
+          ...(getDefaultValueByType(
+            type,
+            parentDefinitionRef.current,
+            customizeDefaultValue,
+          ) as ListValueNode).values,
         ],
       } as ListValueNode,
     };
@@ -398,24 +409,26 @@ const Argument = React.memo(function Argument({
   return (
     <div className={classnames(styles.argument, styles.node, `depth-${depth}`)}>
       <label>
-        {hasFields && (
-          <span
-            className={classnames(
-              styles.selectable,
-              isSelected ? 'CodeMirror-foldgutter-open' : 'CodeMirror-foldgutter-folded',
-            )}
-          />
-        )}
-        <span className={styles.checkbox}>
-          <input
-            checked={isSelected}
-            disabled={isRequired}
-            onChange={onToggleArgument}
-            type="checkbox"
-            value={isSelected.toString()}
-          />
+        <span className={styles.checkboxGroup}>
+          {hasFields && (
+            <span
+              className={classnames(
+                styles.selectable,
+                isSelected ? 'CodeMirror-foldgutter-open' : 'CodeMirror-foldgutter-folded',
+              )}
+            />
+          )}
+          <span className={styles.checkbox}>
+            <input
+              checked={isSelected}
+              disabled={isRequired}
+              onChange={onToggleArgument}
+              type="checkbox"
+              value={isSelected.toString()}
+            />
+          </span>
+          <span className={classnames('arg-name', 'cm-attribute', styles.selectable)}>{name}</span>
         </span>
-        <span className={classnames('arg-name', 'cm-attribute', styles.selectable)}>{name}</span>
         <TypeName className={styles.selectable} isInputType type={type} />
       </label>
 
@@ -462,7 +475,7 @@ const Argument = React.memo(function Argument({
           />
         ))}
 
-      {description && (
+      {showDescription && description && (
         <div className={classnames(styles.description, styles.indented)}>{description}</div>
       )}
 

--- a/src/OutputType.tsx
+++ b/src/OutputType.tsx
@@ -9,7 +9,7 @@ import {
   isInterfaceType,
   isObjectType,
 } from 'graphql';
-import { DefaultValueCustomizerContext, SchemaContext } from './Context';
+import { DefaultValueCustomizerContext, DescriptionContext, SchemaContext } from './Context';
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import {
   generateInlineFragmentFromType,
@@ -44,6 +44,7 @@ const Field = React.memo(function Field({
   selectionNode,
 }: FieldProps) {
   const customizeDefaultValue = useContext(DefaultValueCustomizerContext);
+  const showDescription = useContext(DescriptionContext);
   const parentDefinitionRef = useRef({ definition: field, parentDefinition });
   const selectionNodeRef = useRef(selectionNode);
 
@@ -108,15 +109,29 @@ const Field = React.memo(function Field({
 
   return (
     <div className={classnames(styles.node, styles.fieldNode, `depth-${depth}`)}>
-      <div
-        className={classnames(styles.nameLine, {
-          [styles.selectable]: depth !== 4,
-        })}
-        onClick={onToggleField}
-      >
-        {hasFields && depth !== 4 && (
-          <>
-            <span className={`CodeMirror-foldgutter-${isSelected ? 'open' : 'folded'}`} />
+      <label className={classnames(styles.nameLine, styles.selectable)}>
+        <span className={styles.checkboxGroup}>
+          {hasFields && (
+            <>
+              {depth !== 4 && (
+                <span className={`CodeMirror-foldgutter-${isSelected ? 'open' : 'folded'}`} />
+              )}
+              <span
+                className={classnames(styles.checkbox, {
+                  [styles.hidden]: depth === 4,
+                })}
+              >
+                <input
+                  checked={isSelected}
+                  onChange={onToggleField}
+                  type="checkbox"
+                  value={isSelected.toString()}
+                />
+              </span>
+            </>
+          )}
+
+          {!hasFields && depth !== 4 && (
             <span className={styles.checkbox}>
               <input
                 checked={isSelected}
@@ -125,21 +140,10 @@ const Field = React.memo(function Field({
                 value={isSelected.toString()}
               />
             </span>
-          </>
-        )}
+          )}
 
-        {!hasFields && depth !== 4 && (
-          <span className={styles.checkbox}>
-            <input
-              checked={isSelected}
-              onChange={onToggleField}
-              type="checkbox"
-              value={isSelected.toString()}
-            />
-          </span>
-        )}
-
-        <span className={classnames('field-name', 'cm-property')}>{name}</span>
+          <span className={classnames('field-name', 'cm-property')}>{name}</span>
+        </span>
         {depth !== 4 && <TypeName type={type} />}
         {/* {!selected && hasArgs && <span className="cm-punctuation">()</span>}
         {(!selected || !hasFields) && (
@@ -150,8 +154,8 @@ const Field = React.memo(function Field({
         )}
         {selected && hasArgs && <span className="cm-punctuation">(</span>}
         {selected && hasFields && !hasArgs && <span className="cm-punctuation">{' {'}</span>} */}
-      </div>
-      {description && (
+      </label>
+      {showDescription && description && (
         <div className={classnames(styles.description, { [styles.indented]: depth !== 4 })}>
           {description}
         </div>


### PR DESCRIPTION
Fixing default value generation for lists. Instead of returning ListValueNode when applicable, it would return ObjectValueNode.

Added ability to toggle descriptions for people coming from graphiql-explorer background for better familiarity.